### PR TITLE
feat: support managing multiple Mosquitto password files

### DIFF
--- a/admin-gui/common.py
+++ b/admin-gui/common.py
@@ -18,8 +18,10 @@ import os
 import base64
 import hashlib
 import hmac
+import re
 import subprocess
 import signal
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from ipaddress import ip_address
 from typing import Callable, List, Tuple, Optional, Dict, Any
@@ -45,6 +47,9 @@ MOSQUITTO_CONFIG_DIR = os.environ.get("MOSQUITTO_CONFIG_DIR", "/config")
 
 # Path to the password file used by Mosquitto for MQTT user authentication.
 PWFILE = os.path.join(MOSQUITTO_CONFIG_DIR, "pwfile")
+
+# Directory that can hold additional password files for per-listener auth.
+PASSWD_FILES_DIR = os.path.join(MOSQUITTO_CONFIG_DIR, "passwd_files")
 
 # Paths to TLS and configuration artifacts.
 ACLFILE = os.path.join(MOSQUITTO_CONFIG_DIR, "aclfile")
@@ -81,6 +86,23 @@ log_type warning
 log_type notice
 log_type information
 """
+
+
+@dataclass
+class PasswordFileEntry:
+    """Metadata about a Mosquitto password file."""
+
+    path: str
+    label: str
+    is_default: bool
+    usernames: List[str]
+    exists: bool
+    size_bytes: Optional[int]
+    modified: Optional[datetime]
+
+    @property
+    def user_count(self) -> int:
+        return len(self.usernames)
 
 # -----------------------------------------------------------------------------
 # PBKDF2 helpers and admin credential management
@@ -197,11 +219,29 @@ def logout_button() -> None:
 # -----------------------------------------------------------------------------
 # User management helpers
 
-def read_pw_users() -> List[str]:
-    """Return a list of usernames defined in the Mosquitto password file."""
+_PW_NAME_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _pw_permissions(path: str) -> None:
+    """Best-effort permissions adjustment for a password file."""
+
+    try:
+        subprocess.run(["chown", "1883:1883", path], check=False)
+    except Exception:
+        pass
+    try:
+        subprocess.run(["chmod", "0700", path], check=False)
+    except Exception:
+        pass
+
+
+def read_pw_users(path: Optional[str] = None) -> List[str]:
+    """Return a list of usernames defined in a Mosquitto password file."""
+
+    target = path or PWFILE
     users: List[str] = []
-    if os.path.exists(PWFILE):
-        with open(PWFILE, "r", encoding="utf-8") as f:
+    if os.path.exists(target):
+        with open(target, "r", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or ":" not in line:
@@ -211,50 +251,99 @@ def read_pw_users() -> List[str]:
     return users
 
 
-def upsert_user(username: str, password: str) -> None:
-    """Add or update a user's entry in the password file."""
+def upsert_user(username: str, password: str, path: Optional[str] = None) -> None:
+    """Add or update a user's entry in the specified password file."""
+
+    target = path or PWFILE
     h = mosq_pbkdf2_sha512_hash(password, iterations=20000)
     lines: List[str] = []
-    if os.path.exists(PWFILE):
-        with open(PWFILE, "r", encoding="utf-8") as f:
+    if os.path.exists(target):
+        with open(target, "r", encoding="utf-8") as f:
             lines = [ln for ln in f.read().splitlines() if ln.strip()]
         # Remove any existing entry for this user
         lines = [ln for ln in lines if not ln.startswith(username + ":")]
     lines.append(f"{username}:{h}")
-    os.makedirs(os.path.dirname(PWFILE), exist_ok=True)
-    with open(PWFILE, "w", encoding="utf-8", newline="\n") as f:
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    with open(target, "w", encoding="utf-8", newline="\n") as f:
         f.write("\n".join(lines) + "\n")
-    # Adjust permissions (best effort)
-    try:
-        subprocess.run(["chown", "1883:1883", PWFILE], check=False)
-    except Exception:
-        pass
-    try:
-        subprocess.run(["chmod", "0700", PWFILE], check=False)
-    except Exception:
-        pass
+    if os.path.exists(target):
+        _pw_permissions(target)
 
 
-def delete_user(username: str) -> None:
-    """Remove a user from the password file if present."""
-    if not os.path.exists(PWFILE):
+def delete_user(username: str, path: Optional[str] = None) -> None:
+    """Remove a user from the specified password file if present."""
+
+    target = path or PWFILE
+    if not os.path.exists(target):
         return
-    with open(PWFILE, "r", encoding="utf-8") as f:
+    with open(target, "r", encoding="utf-8") as f:
         lines = [ln for ln in f.read().splitlines() if ln.strip()]
     lines = [ln for ln in lines if not ln.startswith(username + ":")]
-    with open(PWFILE, "w", encoding="utf-8", newline="\n") as f:
+    with open(target, "w", encoding="utf-8", newline="\n") as f:
         if lines:
             f.write("\n".join(lines) + "\n")
         else:
             f.truncate(0)
-    try:
-        subprocess.run(["chown", "1883:1883", PWFILE], check=False)
-    except Exception:
-        pass
-    try:
-        subprocess.run(["chmod", "0700", PWFILE], check=False)
-    except Exception:
-        pass
+    if os.path.exists(target):
+        _pw_permissions(target)
+
+
+def create_password_file(name: str) -> str:
+    """Create a new password file inside PASSWD_FILES_DIR and return its path."""
+
+    cleaned = (name or "").strip()
+    if not cleaned:
+        raise ValueError("Password file name is required.")
+    if not _PW_NAME_RE.fullmatch(cleaned):
+        raise ValueError("Use only letters, numbers, dots, underscores, or dashes.")
+    os.makedirs(PASSWD_FILES_DIR, exist_ok=True)
+    path = os.path.join(PASSWD_FILES_DIR, cleaned)
+    if os.path.exists(path):
+        raise FileExistsError(f"Password file '{cleaned}' already exists.")
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write("")
+    _pw_permissions(path)
+    return path
+
+
+def _build_password_file_entry(path: str, label: str, is_default: bool) -> PasswordFileEntry:
+    usernames = read_pw_users(path)
+    exists = os.path.exists(path)
+    size_bytes: Optional[int] = None
+    modified: Optional[datetime] = None
+    if exists:
+        try:
+            size_bytes = os.path.getsize(path)
+        except OSError:
+            size_bytes = None
+        try:
+            modified = datetime.utcfromtimestamp(os.path.getmtime(path))
+        except OSError:
+            modified = None
+    return PasswordFileEntry(
+        path=path,
+        label=label,
+        is_default=is_default,
+        usernames=usernames,
+        exists=exists,
+        size_bytes=size_bytes,
+        modified=modified,
+    )
+
+
+def discover_password_files(include_default: bool = True) -> List[PasswordFileEntry]:
+    """Return metadata for known Mosquitto password files."""
+
+    entries: List[PasswordFileEntry] = []
+    if include_default:
+        entries.append(_build_password_file_entry(PWFILE, "pwfile (default)", True))
+    if os.path.isdir(PASSWD_FILES_DIR):
+        for name in sorted(os.listdir(PASSWD_FILES_DIR)):
+            full = os.path.join(PASSWD_FILES_DIR, name)
+            if not os.path.isfile(full):
+                continue
+            entries.append(_build_password_file_entry(full, f"passwd_files/{name}", False))
+    return entries
 
 # -----------------------------------------------------------------------------
 # TLS certificate generation

--- a/admin-gui/pages/1_Dashboard.py
+++ b/admin-gui/pages/1_Dashboard.py
@@ -75,7 +75,8 @@ def sha256_file(path: str) -> Optional[str]:
         return None
 
 # ------------------------------ Metrics row ----------------------------------
-users = c.read_pw_users()
+password_files = c.discover_password_files()
+total_users = sum(entry.user_count for entry in password_files)
 sig_dir = getattr(c, "SIGNALS_DIR", "/signals")
 reload_ts = _mtime_str(os.path.join(sig_dir, "reload"))
 restart_ts = _mtime_str(os.path.join(sig_dir, "restart"))
@@ -85,7 +86,7 @@ mqtt_ok, mqtt_err = tcp_check("mosquitto", 1883)
 tls_ok, tls_err   = tls_check("mosquitto", 8883)
 
 col1, col2, col3, col4, col5, col6 = st.columns(6)
-col1.metric("Users", len(users))
+col1.metric("Users", total_users)
 col2.metric("MQTT 1883", "up" if mqtt_ok else "down")
 col3.metric("MQTT TLS 8883", "up" if tls_ok else "down")
 col4.metric("Server CA", "present" if _exists(c.CAFILE) else "missing")
@@ -98,6 +99,22 @@ if not mqtt_ok or not tls_ok:
             st.write(f"1883 error: {mqtt_err}")
         if not tls_ok:
             st.write(f"8883 error: {tls_err}")
+
+if password_files:
+    st.subheader("Password files")
+    table_rows = []
+    for entry in password_files:
+        table_rows.append(
+            {
+                "label": entry.label,
+                "path": entry.path,
+                "users": entry.user_count,
+                "exists": "yes" if entry.exists else "no",
+                "size_bytes": entry.size_bytes if entry.size_bytes is not None else "",
+                "modified_utc": entry.modified.strftime("%Y-%m-%d %H:%M:%S") if entry.modified else "",
+            }
+        )
+    st.dataframe(table_rows, use_container_width=True)
 
 # ------------------------- Signals / recent actions --------------------------
 st.subheader("Recent triggers")
@@ -194,6 +211,7 @@ paths = [
     ("CONFIG_DIR", c.MOSQUITTO_CONFIG_DIR),
     ("MOSQCONF", c.MOSQCONF),
     ("PWFILE", c.PWFILE),
+    ("PASSWD_FILES_DIR", c.PASSWD_FILES_DIR),
     ("ACLFILE", c.ACLFILE),
     ("CAFILE", c.CAFILE),
     ("CERTFILE", c.CERTFILE),

--- a/admin-gui/pages/2_Users.py
+++ b/admin-gui/pages/2_Users.py
@@ -2,8 +2,9 @@
 User management page for the Mosquitto admin app.
 
 This page allows administrators to view, add, update, and delete
-Mosquitto MQTT users. User credentials are stored in the
-Mosquitto password file (`pwfile`) in a PBKDF2‑SHA512 `$7$` format.
+Mosquitto MQTT users. User credentials are stored in Mosquitto
+password files (default `pwfile` or files under `passwd_files/`)
+in a PBKDF2‑SHA512 `$7$` format.
 """
 
 import streamlit as st
@@ -15,16 +16,73 @@ if not c.require_login():
 
 st.set_page_config(page_title="MQTT Users", page_icon="👥", layout="wide")
 st.title("MQTT Users")
+st.caption(
+    "Manage Mosquitto password files and the MQTT accounts stored in them. "
+    "Each listener in mosquitto.conf can reference a different file under "
+    "`/mosquitto/config/passwd_files`."
+)
 
-# Fetch current users
-users = c.read_pw_users()
-
-# Display existing users in a table
-st.subheader("Existing users")
-if users:
-    st.table({"username": users})
+files = c.discover_password_files()
+if not files:
+    st.warning(
+        "No password files discovered. Create one below to get started.")
+    selected_entry = None
+    options = []
 else:
-    st.info("No users defined yet.")
+    options = [entry.path for entry in files]
+    labels = {entry.path: entry.label for entry in files}
+    default_path = st.session_state.get("password_file_select")
+    if default_path not in options:
+        default_path = options[0]
+    selected_path = st.selectbox(
+        "Password file",
+        options,
+        key="password_file_select",
+        index=options.index(default_path) if default_path in options else 0,
+        format_func=lambda p: labels.get(p, p),
+    ) if options else None
+    selected_entry = next((entry for entry in files if entry.path == selected_path), None)
+
+with st.expander("Create new password file", expanded=not files):
+    new_name = st.text_input(
+        "File name",
+        key="new_pwfile_name",
+        help="Stored under passwd_files/. Use letters, numbers, dot, dash, or underscore.",
+    )
+    create_disabled = not new_name.strip()
+    if st.button("Create password file", key="create_pwfile_btn", disabled=create_disabled):
+        try:
+            created_path = c.create_password_file(new_name)
+        except ValueError as exc:
+            st.error(str(exc))
+        except FileExistsError:
+            st.error("A password file with that name already exists.")
+        except Exception as exc:
+            st.error(f"Could not create password file: {exc}")
+        else:
+            st.success(f"Created password file at {created_path}.")
+            st.session_state["password_file_select"] = created_path
+            st.rerun()
+
+if not selected_entry:
+    st.stop()
+
+with st.container(border=True):
+    st.subheader(f"Details — {selected_entry.label}")
+    st.code(selected_entry.path, language=None)
+    meta_cols = st.columns(3)
+    meta_cols[0].metric("Users", selected_entry.user_count)
+    meta_cols[1].metric("Exists", "yes" if selected_entry.exists else "no")
+    size_value = f"{selected_entry.size_bytes} B" if selected_entry.size_bytes is not None else "—"
+    meta_cols[2].metric("Size", size_value)
+    if selected_entry.modified:
+        st.caption(selected_entry.modified.strftime("Last modified: %Y-%m-%d %H:%M:%S UTC"))
+
+st.subheader("Existing users")
+if selected_entry.usernames:
+    st.table({"username": selected_entry.usernames})
+else:
+    st.info("No users defined in this password file yet.")
 
 st.divider()
 
@@ -36,27 +94,27 @@ with col1:
 with col2:
     password = st.text_input("Password (min 8 chars)", type="password", key="new_password")
 
-if st.button("Save User", key="save_user", disabled=(not username or len(password) < 8)):
+save_disabled = not username or len(password) < 8
+if st.button("Save User", key="save_user", disabled=save_disabled):
     if len(password) < 8:
         st.error("Password must be at least 8 characters.")
     else:
-        c.upsert_user(username, password)
-        st.success(f"User '{username}' saved.")
-        # Immediately refresh to update the user list
+        c.upsert_user(username, password, path=selected_entry.path)
+        st.success(f"User '{username}' saved to {selected_entry.label}.")
         st.rerun()
 
 st.divider()
 
 # Section: Delete a user
 st.subheader("Delete User")
-if users:
-    del_user = st.selectbox("Select user", users, key="delete_user_select")
+if selected_entry.usernames:
+    del_user = st.selectbox("Select user", selected_entry.usernames, key="delete_user_select")
     if st.button("Delete Selected User", key="delete_user_button"):
-        c.delete_user(del_user)
-        st.success(f"User '{del_user}' deleted (if existed).")
+        c.delete_user(del_user, path=selected_entry.path)
+        st.success(f"User '{del_user}' deleted (if existed) from {selected_entry.label}.")
         st.rerun()
 else:
-    st.info("No users to delete.")
+    st.info("No users to delete in this password file.")
 
 # Logout button
 c.logout_button()

--- a/admin-gui/pages/7_About.py
+++ b/admin-gui/pages/7_About.py
@@ -21,7 +21,7 @@ st.markdown(
     This Streamlit application provides a simple, file-backed admin UI for an
     Eclipse Mosquitto broker. It focuses on:
     - Local, file-based **admin authentication** (no external DB).
-    - Managing MQTT **users** (Mosquitto `pwfile`).
+    - Managing MQTT **users** (Mosquitto password files).
     - Generating **server TLS** credentials and optionally a **client CA**.
     - Editing `mosquitto.conf` directly in the browser.
     - Applying changes via **Reload** (SIGHUP) or **Restart** (SIGTERM) using a
@@ -66,6 +66,7 @@ st.code(
 SIGNALS_DIR          = {getattr(c, "SIGNALS_DIR", "/signals")}
 MOSQCONF             = {c.MOSQCONF}
 PWFILE               = {c.PWFILE}
+PASSWD_FILES_DIR     = {c.PASSWD_FILES_DIR}
 ACLFILE              = {c.ACLFILE}
 CAFILE               = {c.CAFILE}
 CERTFILE             = {c.CERTFILE}
@@ -80,7 +81,8 @@ st.markdown(
     **Where things live**
     - **Admin credentials** (UI login): stored in a file within `ADMIN_CONFIG_DIR`
       as `$7$` PBKDF2-SHA512 (Mosquitto-compatible).
-    - **MQTT users**: stored in `PWFILE` with `$7$` hashes; updated in-place.
+    - **MQTT users**: stored in `PWFILE` (default) or additional files under
+      `PASSWD_FILES_DIR`, all using `$7$` hashes.
     - **TLS artifacts**: written under `MOSQUITTO_CONFIG_DIR` (server CA, server cert/key,
       optional client CA).
     - **Signals**: files created in `SIGNALS_DIR` instruct the watcher to Reload/Restart.


### PR DESCRIPTION
## Summary
- add shared utilities to discover and manage multiple Mosquitto password files under /mosquitto/config
- update the MQTT Users page to select, inspect, and create password files before editing user entries
- surface password file metadata on the dashboard and document the new layout on the About page

## Testing
- python -m compileall admin-gui

------
https://chatgpt.com/codex/tasks/task_e_68cf92be36408331979cdcb833243d80