### PR TITLE
Fix password file selection rerun handling

### DIFF
--- a/admin-gui/pages/2_Users.py
+++ b/admin-gui/pages/2_Users.py
@@ -22,6 +22,11 @@ st.caption(
     "`/mosquitto/config/passwd_files`."
 )
 
+pending_select_key = "password_file_select_pending"
+pending_value = st.session_state.pop(pending_select_key, None)
+if pending_value is not None:
+    st.session_state["password_file_select"] = pending_value
+
 files = c.discover_password_files()
 if not files:
     st.warning(
@@ -61,7 +66,8 @@ with st.expander("Create new password file", expanded=not files):
             st.error(f"Could not create password file: {exc}")
         else:
             st.success(f"Created password file at {created_path}.")
-            st.session_state["password_file_select"] = created_path
+            st.session_state[pending_select_key] = created_path
+            st.session_state["new_pwfile_name"] = ""
             st.rerun()
 
 if not selected_entry:


### PR DESCRIPTION
## Summary
- promote any pending password file selection into the main select key before rendering the selectbox
- queue new password file selections and clear the creation input before rerunning after creation

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cf99c99ec08331a9527e6f9bf4f212